### PR TITLE
feat: Implement dynamic network switching in BridgeService

### DIFF
--- a/src/plugins/bridge/bridge.service.ts
+++ b/src/plugins/bridge/bridge.service.ts
@@ -138,6 +138,16 @@ export class BridgeService {
     this.xflowsApi = XFLOWS_API;
   }
 
+  // Method to switch networks dynamically
+  setNetwork(network: 'mainnet' | 'testnet') {
+    this.network = network;
+    this.wanbridgeApi = WANBRIDGE_API[network];
+  }
+
+  getNetwork(): 'mainnet' | 'testnet' {
+    return this.network;
+  }
+
   // ==================== WANBRIDGE BASIC APIs ====================
 
   @Tool({


### PR DESCRIPTION
- Add setNetwork method to allow dynamic switching between mainnet and testnet
- Introduce getNetwork method to retrieve the current network setting
- Enhance BridgeService functionality for improved network management